### PR TITLE
Update Dockerfile for Metz-connect

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ RUN npm install --save \
     node-red-contrib-ui-led \
     node-red-dashboard \
     node-red-node-openweathermap  \
-    node-red-contrib-influxdb
+    node-red-contrib-influxdb \
+    node-red-contrib-buffer-parser
 
 FROM nodered/node-red:${NODERED_VERSION}-${NODEJS_VERSION_MAJOR}-minimal as base
 USER root


### PR DESCRIPTION
Buffer-parser is required for some of the Metz-connect subflows and as such should be installed automatically.